### PR TITLE
Refactor GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,28 @@
-name: Publish package to npm
+# See https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+
+name: Publish Package
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing the npm package, modernizing the configuration and improving security and reliability. The most important changes are grouped below:

**Workflow Trigger and Structure Updates:**

* Changed the workflow trigger from running on release publication or manual dispatch to running automatically on any tag push matching the pattern `v*` (e.g., `v1.2.3`). This streamlines the release process and ensures packages are published only on versioned tags.
* Simplified the workflow structure by removing conditional logic and aligning with npm's recommended GitHub Actions configuration for trusted publishers.

**Security and Best Practices:**

* Added the `id-token: write` permission to support OIDC authentication, improving security for npm publishing.
* Disabled package manager caching during release builds to ensure clean, reproducible releases.

**Build and Test Steps:**

* Added explicit `npm ci`, `npm run build --if-present`, and `npm test` steps before publishing to ensure dependencies are installed, the package is built, and tests pass prior to publishing.